### PR TITLE
(4-2)初級 価格フォーマット

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -171,7 +171,10 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span
+                        th:utext="${#numbers.formatInteger(employee.salary, 0, 'COMMA') + '円'}"
+                        >400000円</span
+                      >
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
給料の表記を「233,800円」のように3桁ごとにカンマが入るよう修正しました
レビューお願いします